### PR TITLE
Restrict extension to running on linkedin.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
    "default_popup": "popup.html"
   },
   "content_scripts": [{
-  			"matches": ["<all_urls>"],
+  			"matches": ["*://*.linkedin.com/*"],
   			"js": ["jquery-1.11.3.min.js", "content.js"]
   }],
    "background": {
@@ -18,7 +18,6 @@
         "persistent": false
    },
   "permissions": [
-   "activeTab",
    "*://*.linkedin.com/*"
    ]
 }


### PR DESCRIPTION
Updated the manifest file so the extension will run on linkedin.com.

This prevents the user from getting a warning about the extension accessing all data on all websites. It will also save memory by not running the content script on other websites.
